### PR TITLE
Minor README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Note : The softpots are placed over the force sensitive resistors ( see picture 
 * Neopixel : D21
 
 ### First time calibration
+* Set the A0 potentiometer all the way down on the midi shield.
 * Uncomment Serial.begin(115200) and comment Serial.begin(31250);
 * Uncomment calibrate() at line 168
-* To calibrate the softpots, open a serial console. When it says "waiting" press on one of the softstick and press the middle button on the midi shield. Repeat for N_FRET times and repeat the same for the second softpot. When it's done the program will write the calibration in to the EEPROM and you may comment the line 168 and switch the serial to 31250 baud again. 
+* To calibrate the softpots, open a serial console. When it says "waiting" press on one of the softstick and set the A0 potentiometer up on the midi shield. Once you see the confirmation in the console output turn it back down and proceed back to the next fret. Repeat for N_FRET times and repeat the same for the second softpot. When it's done the program will write the calibration in to the EEPROM and you may comment the line 168 and switch the serial to 31250 baud again. 
 * The notes that are close to the Arduino are lower
 
 ## Manual


### PR DESCRIPTION
If we take a look at your code

short `checkTriggered(int i)` function, which is used in the calibration to determine if fret value should be read, we see that it is reading the `T_pins[i]`

https://github.com/HanYangZhao/MidiLin/blob/9c60da8b9a82aec2ae8316268fd33cd2846bd7f7/midi_ribbon_2/midi_ribbon_2.ino#L528

which are `T0, T1, T2, T3`

https://github.com/HanYangZhao/MidiLin/blob/9c60da8b9a82aec2ae8316268fd33cd2846bd7f7/midi_ribbon_2/midi_ribbon_2.ino#L101

which are all `A0`

https://github.com/HanYangZhao/MidiLin/blob/9c60da8b9a82aec2ae8316268fd33cd2846bd7f7/midi_ribbon_2/midi_ribbon_2.ino#L30-L34

and `A0` is not the middle switch, this is the potentiometer.

Description was inaccurate so I took liberty to update it. If you find it right feel free to merge.